### PR TITLE
Add RF A4 Blade configuration generator

### DIFF
--- a/CommandControl/Outputs/blade_rf_a4.txt
+++ b/CommandControl/Outputs/blade_rf_a4.txt
@@ -1,0 +1,12 @@
+set frequency tx 1300M
+set frequency rx 1300M
+set samplerate tx 38M
+set samplerate rx 38M
+set bandwidth tx 38M
+set bandwidth rx 38M
+set txvga1 0
+set txvga2 10
+set gain rx 40
+tx config file=my_chirp.bin format=bin repeat=100 delay=0
+tx start
+rx config file=rx_chirp.bin format=bin n=3800

--- a/CommandControl/blade_rf_a4_config.json
+++ b/CommandControl/blade_rf_a4_config.json
@@ -1,0 +1,16 @@
+{
+  "frequency": {"tx": "1300M", "rx": "1300M"},
+  "samplerate": {"tx": "38M", "rx": "38M"},
+  "bandwidth": {"tx": "38M", "rx": "38M"},
+  "txvga1": 0,
+  "txvga2": 10,
+  "rx_gain": 40,
+  "tx": {
+    "config": {"file": "my_chirp.bin", "format": "bin", "repeat": 100, "delay": 0},
+    "start": true
+  },
+  "rx": {
+    "config": {"file": "rx_chirp.bin", "format": "bin", "n": 3800},
+    "start": false
+  }
+}

--- a/CommandControl/configure_blade.py
+++ b/CommandControl/configure_blade.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+from pathlib import Path
+
+
+def build_commands(cfg: dict) -> list:
+    lines = [
+        f"set frequency tx {cfg['frequency']['tx']}",
+        f"set frequency rx {cfg['frequency']['rx']}",
+        f"set samplerate tx {cfg['samplerate']['tx']}",
+        f"set samplerate rx {cfg['samplerate']['rx']}",
+        f"set bandwidth tx {cfg['bandwidth']['tx']}",
+        f"set bandwidth rx {cfg['bandwidth']['rx']}",
+        f"set txvga1 {cfg['txvga1']}",
+        f"set txvga2 {cfg['txvga2']}",
+        f"set gain rx {cfg['rx_gain']}",
+    ]
+    tx_cfg = cfg.get('tx', {})
+    tx_config = tx_cfg.get('config')
+    if tx_config:
+        lines.append(
+            "tx config file={file} format={format} repeat={repeat} delay={delay}".format(**tx_config)
+        )
+    if tx_cfg.get('start'):
+        lines.append('tx start')
+    rx_cfg = cfg.get('rx', {})
+    rx_config = rx_cfg.get('config')
+    if rx_config:
+        parts = [
+            f"file={rx_config['file']}",
+            f"format={rx_config['format']}",
+        ]
+        if 'n' in rx_config:
+            parts.append(f"n={rx_config['n']}")
+        lines.append('rx config ' + ' '.join(parts))
+    if rx_cfg.get('start'):
+        lines.append('rx start')
+    return lines
+
+
+def main():
+    base_dir = Path(__file__).resolve().parent
+    cfg_path = base_dir / 'blade_rf_a4_config.json'
+    out_dir = base_dir / 'Outputs'
+    out_dir.mkdir(exist_ok=True)
+    out_path = out_dir / 'blade_rf_a4.txt'
+
+    with cfg_path.open() as f:
+        cfg = json.load(f)
+
+    lines = build_commands(cfg)
+    with out_path.open('w') as f:
+        f.write('\n'.join(lines) + '\n')
+
+    try:
+        subprocess.run(['bladeRF-cli', '-s', str(out_path)], check=True)
+    except FileNotFoundError:
+        print('bladeRF-cli not found. Please install the BladeRF command line tools.')
+    except subprocess.CalledProcessError as e:
+        print('bladeRF-cli returned an error:', e)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add JSON configuration for RF A4 blade parameters
- add Python script that generates command text and attempts to execute it via BladeRF CLI
- include generated command script in Outputs for triggering

## Testing
- `python3 CommandControl/configure_blade.py` *(fails: bladeRF-cli not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6300fb7488323a807adf5fc157df8